### PR TITLE
fix: use RPC block method to get block hash

### DIFF
--- a/near_api/account.py
+++ b/near_api/account.py
@@ -36,7 +36,8 @@ class Account(object):
 
     def _sign_and_submit_tx(self, receiver_id: str, actions: List['transactions.Action']) -> dict:
         self._access_key['nonce'] += 1
-        block_hash = self._provider.get_status()['sync_info']['latest_block_hash']
+        block = self._provider.get_block()
+        block_hash = block['header']['hash']
         block_hash = base58.b58decode(block_hash.encode('utf8'))
         serialized_tx = transactions.sign_and_serialize_transaction(
             receiver_id, self._access_key['nonce'], actions, block_hash, self._signer)

--- a/near_api/providers.py
+++ b/near_api/providers.py
@@ -124,8 +124,12 @@ class JsonProvider(object):
                 'finality': finality
             }, timeout=timeout)
 
-    def get_block(self, block_id: str, timeout: 'TimeoutType' = 2.0) -> dict:
-        return self.json_rpc("block", [block_id], timeout=timeout)
+    def get_block(self, block_id = None, timeout: 'TimeoutType' = 2.0) -> dict:
+        params = {}
+        if block_id:
+            params['block_id'] = block_id
+        params['finality'] = "final"
+        return self.json_rpc("block", params, timeout=timeout)
 
     def get_chunk(self, chunk_id: str, timeout: 'TimeoutType' = 2.0) -> dict:
         return self.json_rpc("chunk", [chunk_id], timeout=timeout)


### PR DESCRIPTION
use `get_block()` to get recent block hash instead of `get_status()` (which is not supported by Infura)